### PR TITLE
Updated feed URL (#336)

### DIFF
--- a/docs/Documentation/Gallery-overview.markdown
+++ b/docs/Documentation/Gallery-overview.markdown
@@ -13,7 +13,7 @@ You can also access the Gallery from within your Orchard site in order to downlo
 If you are a developer who writes modules or themes for Orchard, you are probably interested in sharing your module with others in the gallery. For information about how to do this, see [Contributing a Module or Theme to the Gallery](Contributing-a-module-or-theme-to-the-gallery).
 
 ## Registering Additional Gallery Feeds
-The Orchard Gallery is just one gallery that you can browse. By default, a single feed is exposed from [http://packages.orchardproject.net/FeedService.svc](http://packages.orchardproject.net/FeedService.svc). Orchard allows you to register additional feeds for other galleries. To register a feed, expand the dashboard **Settings** section and then click **Gallery**.  On the **Gallery Feeds** page you can add new feeds or delete existing ones. For more information, see [Registering Additional Gallery Feeds](Module gallery feeds).
+The Orchard Gallery is just one gallery that you can browse. By default, a single feed is exposed from [https://gallery.orchardproject.net/api/FeedService](https://gallery.orchardproject.net/api/FeedService). Orchard allows you to register additional feeds for other galleries. To register a feed, expand the dashboard **Settings** section and then click **Gallery**.  On the **Gallery Feeds** page you can add new feeds or delete existing ones. For more information, see [Registering Additional Gallery Feeds](Module gallery feeds).
 
 If you want to set up your own gallery, a reference implementation for exposing a gallery feed and website is available on [OrchardGallery.CodePlex.com](http://orchardgallery.codeplex.com) and [GalleryServer.CodePlex.com](http://galleryserver.codeplex.com).  
   

--- a/docs/Documentation/Module-gallery-feeds.markdown
+++ b/docs/Documentation/Module-gallery-feeds.markdown
@@ -9,7 +9,7 @@ The **Gallery Feeds** screen displays currently registered feeds.
 
 ![](../Upload/screenshots_675/galleryfeedupdated.png)
 
-As the illustration shows, by default an Orchard site provides a single registered gallery feed from [http://packages.orchardproject.net/FeedService.svc](http://packages.orchardproject.net/FeedService.svc). You can add feeds or delete existing feeds.
+As the illustration shows, by default an Orchard site provides a single registered gallery feed from [https://gallery.orchardproject.net/api/FeedService](https://gallery.orchardproject.net/api/FeedService). You can add feeds or delete existing feeds.
 
 To register an additional feed, click the **Add Feed** button.
 

--- a/docs/Documentation/Packaging-and-sharing-a-module.markdown
+++ b/docs/Documentation/Packaging-and-sharing-a-module.markdown
@@ -46,7 +46,7 @@ Orchard uses the [NuGet](http://nuget.org) packaging format to create module pac
 
 Once you've created a module package, you can share it easily with others.  Orchard provides the ability to browse and install a module from the "Modules" section of the Orchard admin panel.  Refer to the [Installing and upgrading modules](Installing-and-upgrading-modules) topic for more details.
 
-Additionally, Orchard provides a Gallery feature that can register one or more gallery feeds of module extensions (OData format).  Users can easily install modules from any registered feed.  A default gallery feed is exposed from this website, at [http://packages.orchardproject.net/FeedService.svc](http://packages.orchardproject.net/FeedService.svc).  For more information, refer to the [Module gallery feeds](Module gallery feeds) topic.
+Additionally, Orchard provides a Gallery feature that can register one or more gallery feeds of module extensions (OData format).  Users can easily install modules from any registered feed.  A default gallery feed is exposed from this website, at [https://gallery.orchardproject.net/api/FeedService](https://gallery.orchardproject.net/api/FeedService).  For more information, refer to the [Module gallery feeds](Module gallery feeds) topic.
 
 You can visit the Gallery admin panel menu to browse and install available modules and themes online.  The [http://gallery.orchardproject.net/](http://gallery.orchardproject.net/) website provides a browsable front-end for finding and downloading available modules and themes too.
 


### PR DESCRIPTION
Fixes #335 by replacing all references to the old feed URL with the new feed URL. I've made the URLs https:// as this is the form that was mentioned in Orchard/OrchardCMS#7367

I have *not* added anything to the change log at the bottom of the pages as this is a relatively minor change, but am happy to do so!